### PR TITLE
Backoffs now monotonic

### DIFF
--- a/lib/tortoise311/connection/backoff.ex
+++ b/lib/tortoise311/connection/backoff.ex
@@ -20,8 +20,8 @@ defmodule Tortoise311.Connection.Backoff do
     {current, %State{state | value: current}}
   end
 
-  def next(%State{value: value} = state) do
-    current = min(value * 2, state.max_interval)
+  def next(%State{} = state) do
+    current = min(state.value * 2, state.max_interval)
     {current, %State{state | value: current}}
   end
 

--- a/lib/tortoise311/connection/backoff.ex
+++ b/lib/tortoise311/connection/backoff.ex
@@ -20,11 +20,6 @@ defmodule Tortoise311.Connection.Backoff do
     {current, %State{state | value: current}}
   end
 
-  def next(%State{max_interval: same, value: same} = state) do
-    current = state.min_interval
-    {current, %State{state | value: current}}
-  end
-
   def next(%State{value: value} = state) do
     current = min(value * 2, state.max_interval)
     {current, %State{state | value: current}}

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -10,9 +10,7 @@ defmodule Tortoise311.Connection.BackoffTest do
     backoff = Backoff.new(min_interval: 100, max_interval: 300)
     assert {^min, backoff} = Backoff.next(backoff)
     {_, backoff} = Backoff.next(backoff)
-    assert {^max, backoff} = Backoff.next(backoff)
-    # should roll back to min interval now
-    assert {^min, _} = Backoff.next(backoff)
+    assert {^max, _} = Backoff.next(backoff)
   end
 
   test "reset" do

--- a/test/tortoise/events_test.exs
+++ b/test/tortoise/events_test.exs
@@ -53,7 +53,7 @@ defmodule Tortoise311.EventsTest do
 
       # the subscriber should receive the connection and unregister
       # itself from the connection event
-      assert_receive {:received, ^connection}
+      assert_receive {:received, ^connection}, 1_000
       assert [] = Registry.keys(Tortoise311.Events, child)
     end
   end
@@ -82,7 +82,7 @@ defmodule Tortoise311.EventsTest do
         end)
 
       # make sure the child process is ready
-      assert_receive :ready
+      assert_receive :ready, 1_000
 
       # dispatch the connection
       connection = {context.transport, context.client}
@@ -90,13 +90,13 @@ defmodule Tortoise311.EventsTest do
 
       # the subscriber should receive the connection and it should
       # still be registered for new connections
-      assert_receive {:received, ^connection}
+      assert_receive {:received, ^connection}, 1_000
       assert [:connection] = Registry.keys(Tortoise311.Events, child)
 
       context = run_setup(context, :setup_connection)
       new_connection = {context.transport, context.client}
       :ok = Tortoise311.Events.dispatch(context.client_id, :connection, new_connection)
-      assert_receive {:received, ^new_connection}
+      assert_receive {:received, ^new_connection}, 1_000
       assert [:connection] = Registry.keys(Tortoise311.Events, child)
     end
   end


### PR DESCRIPTION
A connection's backoffs no longer goes back to min interval