### PR TITLE
Disable Connection.Controller before shutdown

### DIFF
--- a/test/tortoise/connection/controller_test.exs
+++ b/test/tortoise/connection/controller_test.exs
@@ -123,8 +123,8 @@ defmodule Tortoise311.Connection.ControllerTest do
     assert {:ok, pid} = Controller.start_link(opts)
     assert Process.alive?(pid)
     assert :ok = Controller.stop(context.client_id)
-    refute Process.alive?(pid)
-    assert_receive {:terminating, :normal}
+    state = Controller.info(context.client_id)
+    assert state.status == :stopped
   end
 
   describe "Connection callback" do


### PR DESCRIPTION
Before: The Connection.Controller process is stopped on disconnection just before its supervisor is shutdown normally. In the interval, the supervisor tries to restart the (permanent) process.

Proposed: Keep the Connection.Controller alive but disable it before it is terminated by its supervisor shutting down.

Solves issue #34 