### PR TITLE
Add :enable_telemtry connection option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ You can choose to register any or all of the following metrics in the Applicatio
       Telemetry.Metrics.sum("tortoise311.connection.rx_bytes")
 ```
 
+Telemetry may be disabled (one less process per connnection) if not needed, by passing `enable_telemetry: false` as a connection option.
+
 ## Installation
 
 Tortoise311 can be installed by adding `tortoise311` to your list of

--- a/lib/tortoise311/connection.ex
+++ b/lib/tortoise311/connection.ex
@@ -44,6 +44,7 @@ defmodule Tortoise311.Connection do
                   [{Tortoise311.topic_filter(), Tortoise311.qos()}]
                   | Tortoise311.Package.Subscribe.t()}
                | {:clean_session, boolean()}
+               | {:enable_telemetry, boolean()}
                | {:handler, {atom(), term()}},
              options: [option]
   def start_link(connection_opts, opts \\ []) do
@@ -75,7 +76,7 @@ defmodule Tortoise311.Connection do
       end
 
     # @todo, validate that the handler is valid
-    connection_opts = Keyword.take(connection_opts, [:client_id, :handler])
+    connection_opts = Keyword.take(connection_opts, [:client_id, :handler, :enable_telemetry])
     initial = {server, connect, backoff, subscriptions, connection_opts}
     opts = Keyword.merge(opts, name: via_name(client_id))
     GenServer.start_link(__MODULE__, initial, opts)

--- a/lib/tortoise311/connection/supervisor.ex
+++ b/lib/tortoise311/connection/supervisor.ex
@@ -16,13 +16,13 @@ defmodule Tortoise311.Connection.Supervisor do
 
   @impl Supervisor
   def init(opts) do
-    children = [
+    base_children = [
       {Inflight, Keyword.take(opts, [:client_id])},
       {Receiver, Keyword.take(opts, [:client_id])},
       {Controller, Keyword.take(opts, [:client_id, :handler])},
-      {Telemetry, Keyword.take(opts, [:client_id])}
     ]
-
+    optional_telemetry = Keyword.get(opts, :enable_telemetry, true) && {Telemetry, Keyword.take(opts, [:client_id])}
+    children = if optional_telemetry, do: base_children ++ [optional_telemetry], else: base_children
     Supervisor.init(children, strategy: :rest_for_one)
   end
 end

--- a/lib/tortoise311/connection/supervisor.ex
+++ b/lib/tortoise311/connection/supervisor.ex
@@ -21,8 +21,8 @@ defmodule Tortoise311.Connection.Supervisor do
       {Receiver, Keyword.take(opts, [:client_id])},
       {Controller, Keyword.take(opts, [:client_id, :handler])},
     ]
-    optional_telemetry = Keyword.get(opts, :enable_telemetry, true) && {Telemetry, Keyword.take(opts, [:client_id])}
-    children = if optional_telemetry, do: base_children ++ [optional_telemetry], else: base_children
+    with_telemetry? = Keyword.get(opts, :enable_telemetry, true)
+    children = if with_telemetry?, do: base_children ++ [{Telemetry, Keyword.take(opts, [:client_id])}], else: base_children
     Supervisor.init(children, strategy: :rest_for_one)
   end
 end


### PR DESCRIPTION
Add :enable_telemtry connection option. Use it's value (default true)… to optionally include the Telemetry spec in Connection.Supervisor's children.

Glad to do this differently as directed. But it's a start to get the ball rolling.

The inclusion in README.md may be more than worth sharing. I note that many of the connection_options are left as a "discovery for the interested student."