### PR TITLE
Add jitter to backoff delays

### DIFF
--- a/lib/tortoise311/connection/backoff.ex
+++ b/lib/tortoise311/connection/backoff.ex
@@ -3,7 +3,7 @@ defmodule Tortoise311.Connection.Backoff do
 
   alias __MODULE__, as: State
 
-  defstruct min_interval: 100, max_interval: 30_000, value: nil
+  defstruct min_interval: 100, max_interval: 30_000, jitter_percent: 0.5, value: nil
 
   @doc """
   Create an opaque data structure that describe a incremental
@@ -12,21 +12,26 @@ defmodule Tortoise311.Connection.Backoff do
   def new(opts) do
     min_interval = Keyword.get(opts, :min_interval, 100)
     max_interval = Keyword.get(opts, :max_interval, 30_000)
+    jitter_percent = Keyword.get(opts, :jitter_percent, 0)
 
-    %State{min_interval: min_interval, max_interval: max_interval}
+    %State{min_interval: min_interval, max_interval: max_interval, jitter_percent: jitter_percent}
   end
 
   def next(%State{value: nil} = state) do
     current = state.min_interval
-    {current, %State{state | value: current}}
+    {jitter(current, state.jitter_percent), %State{state | value: current}}
   end
 
   def next(%State{} = state) do
     current = min(state.value * 2, state.max_interval)
-    {current, %State{state | value: current}}
+    {jitter(current, state.jitter_percent), %State{state | value: current}}
   end
 
   def reset(%State{} = state) do
     %State{state | value: nil}
+  end
+
+  defp jitter(delay, percent) do
+    round(delay * (1 - percent * (0.5 - :rand.uniform())))
   end
 end

--- a/test/tortoise/connection/backoff_test.exs
+++ b/test/tortoise/connection/backoff_test.exs
@@ -7,17 +7,33 @@ defmodule Tortoise311.Connection.BackoffTest do
   test "should not exceed maximum interval time" do
     min = 100
     max = 300
-    backoff = Backoff.new(min_interval: 100, max_interval: 300)
+    backoff = Backoff.new(min_interval: 100, max_interval: 300, jitter_percent: 0)
     assert {^min, backoff} = Backoff.next(backoff)
     {_, backoff} = Backoff.next(backoff)
     assert {^max, _} = Backoff.next(backoff)
   end
 
   test "reset" do
-    backoff = Backoff.new(min_interval: 10)
+    backoff = Backoff.new(min_interval: 10, jitter_percent: 0)
     assert {_, backoff = snapshot} = Backoff.next(backoff)
     assert {_, backoff} = Backoff.next(backoff)
     assert %Backoff{} = backoff = Backoff.reset(backoff)
     assert {_, ^snapshot} = Backoff.next(backoff)
+  end
+
+  test "jitters backoff" do
+    backoff = Backoff.new(min_interval: 100, max_interval: 100, jitter_percent: 0.5)
+
+    {result, _backoff} =
+      Enum.reduce(1..1000, {[], backoff}, fn _, {acc, b} ->
+        {delay, b} = Backoff.next(b)
+        {[delay | acc], b}
+      end)
+
+    mean = Enum.sum(result) / length(result)
+    assert_in_delta mean, 100, 2
+
+    unique_values = Enum.count(Enum.frequencies(result))
+    assert unique_values > 1
   end
 end


### PR DESCRIPTION
Previously the backoff delay algorithm was a simple exponential backoff
with no jitter. Adding jitter helps mitigate a thundering herd issue
when something causes a lot of devices to reconnect at the same time.

The jitter can be set. The default is +-50% of the target delay.

Fixes #16.
