### PR TITLE
Add keep_alive_timeout option

### DIFF
--- a/lib/tortoise311/package/connect.ex
+++ b/lib/tortoise311/package/connect.ex
@@ -13,6 +13,7 @@ defmodule Tortoise311.Package.Connect do
             password: binary() | nil,
             clean_session: boolean(),
             keep_alive: non_neg_integer(),
+            keep_alive_timeout: non_neg_integer(),
             client_id: Tortoise311.client_id(),
             will: Package.Publish.t() | nil
           }
@@ -25,6 +26,7 @@ defmodule Tortoise311.Package.Connect do
             password: nil,
             clean_session: true,
             keep_alive: 60,
+            keep_alive_timeout: 5000,
             client_id: nil,
             will: nil
 


### PR DESCRIPTION
Using this library our client webserver is getting `ping_timeout`s every now and then and before writing some extra code we wanted to try extending the timeout period to see how that changes the frequency of `ping_timeouts`. Not sure if this is the right place to store this option, happy to change it to whatever is best. Thanks!